### PR TITLE
feat(rbac): Allow to configure the attribute from which to extract us…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -70,6 +70,17 @@ The roles are checked against request attribute `gravitee.attribute.user.roles`.
 }
 ----
 
+==== Gateway configuration (gravitee.yml)
+[source, yaml]
+----
+  policy:
+    rbac:
+      attributes:
+        roles: gateway.roles
+----
+
+The `policy.rbac.attributes.roles` allow to configure the context attribute from which the gateway would extract the user's roles.
+
 == Errors
 
 === HTTP status codes

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-role-based-access-control</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
 
     <name>Gravitee.io APIM - Policy - Role-Based-Access-Control</name>
     <description>Control access to a resource by specifying the required roles to access it</description>
@@ -34,9 +34,9 @@
     </parent>
 
     <properties>
-        <gravitee-gateway-api.version>1.16.1</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.5.0</gravitee-policy-api.version>
         <gravitee-bom.version>5.0.0</gravitee-bom.version>
+        <gravitee-gateway-api.version>3.4.0</gravitee-gateway-api.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
 
         <json-schema-generator-maven-plugin.version>1.1.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
@@ -86,6 +86,12 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/io/gravitee/policy/rbac/RoleBasedAccessControlPolicy.java
+++ b/src/main/java/io/gravitee/policy/rbac/RoleBasedAccessControlPolicy.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.policy.rbac;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
@@ -23,14 +24,20 @@ import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.api.PolicyResult;
 import io.gravitee.policy.api.annotations.OnRequest;
 import io.gravitee.policy.rbac.configuration.RoleBasedAccessControlPolicyConfiguration;
-import java.util.Collection;
-import java.util.List;
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class RoleBasedAccessControlPolicy {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RoleBasedAccessControlPolicy.class);
 
     /**
      * The associated configuration to this Role-Based-Access-Control Policy
@@ -43,6 +50,13 @@ public class RoleBasedAccessControlPolicy {
 
     static final String RBAC_FORBIDDEN = "RBAC_FORBIDDEN";
 
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private String userRolesAttribute;
+
+    static final String RBAC_USER_ROLES_ATTRIBUTE_KEY = "policy.rbac.attributes.roles";
+    static final String DEFAULT_RBAC_USER_ROLES_ATTRIBUTE = ExecutionContext.ATTR_USER_ROLES;
+
     /**
      * Create a new Role-Based-Access-Control Policy instance based on its associated configuration
      *
@@ -54,7 +68,7 @@ public class RoleBasedAccessControlPolicy {
 
     @OnRequest
     public void onRequest(Request request, Response response, ExecutionContext context, PolicyChain policyChain) {
-        Object userRolesAttribute = context.getAttribute(ExecutionContext.ATTR_USER_ROLES);
+        Object userRolesAttribute = context.getAttribute(getRolesAttribute(context));
 
         if (userRolesAttribute == null) {
             // No role for the current HTTP request
@@ -67,14 +81,10 @@ public class RoleBasedAccessControlPolicy {
             );
         } else if (configuration.hasRoles()) {
             if (userRolesAttribute instanceof List) {
-                if (hasRequiredRoles((List) userRolesAttribute)) {
-                    policyChain.doNext(request, response);
-                } else {
-                    // The user roles do not contain one of the expected role
-                    policyChain.failWith(
-                        PolicyResult.failure(RBAC_FORBIDDEN, HttpStatusCode.FORBIDDEN_403, "User is not allowed to access this route.")
-                    );
-                }
+                processRoles((List) userRolesAttribute, policyChain, context);
+            } else if (userRolesAttribute instanceof String) {
+                Set<String> roles = parseString((String) userRolesAttribute);
+                processRoles(roles, policyChain, context);
             } else {
                 // The user roles structure is not the one expected
                 policyChain.failWith(
@@ -84,6 +94,28 @@ public class RoleBasedAccessControlPolicy {
         } else {
             // No required role defined, continue request processing
             policyChain.doNext(request, response);
+        }
+    }
+
+    private void processRoles(final Collection<String> userRoles, PolicyChain policyChain, ExecutionContext context) {
+        if (hasRequiredRoles(userRoles)) {
+            policyChain.doNext(context.request(), context.response());
+        } else {
+            // The user roles do not contain one of the expected role
+            policyChain.failWith(
+                PolicyResult.failure(RBAC_FORBIDDEN, HttpStatusCode.FORBIDDEN_403, "User is not allowed to access this route.")
+            );
+        }
+    }
+
+    private Set<String> parseString(String rolesStr) {
+        // Two cases
+        // 2_ json format
+        // 1_ array of string (separated by a space)
+        try {
+            return MAPPER.readValue(rolesStr, Set.class);
+        } catch (IOException e) {
+            return Arrays.stream(rolesStr.split("\\s+|,\\s*")).collect(Collectors.toSet());
         }
     }
 
@@ -97,5 +129,14 @@ public class RoleBasedAccessControlPolicy {
         } else {
             return userRoles.stream().anyMatch(configuration.getRoles()::contains);
         }
+    }
+
+    private String getRolesAttribute(ExecutionContext context) {
+        if (userRolesAttribute == null) {
+            Environment environment = context.getComponent(Environment.class);
+            userRolesAttribute = environment.getProperty(RBAC_USER_ROLES_ATTRIBUTE_KEY, DEFAULT_RBAC_USER_ROLES_ATTRIBUTE);
+        }
+
+        return userRolesAttribute;
     }
 }

--- a/src/test/java/io/gravitee/policy/rbac/RoleBasedAccessControlPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/rbac/RoleBasedAccessControlPolicyTest.java
@@ -17,7 +17,9 @@ package io.gravitee.policy.rbac;
 
 import static org.mockito.Mockito.*;
 
+import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
@@ -26,11 +28,13 @@ import io.gravitee.policy.api.PolicyResult;
 import io.gravitee.policy.rbac.configuration.RoleBasedAccessControlPolicyConfiguration;
 import java.util.Arrays;
 import java.util.HashSet;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.core.env.Environment;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -54,11 +58,28 @@ public class RoleBasedAccessControlPolicyTest {
     @Mock
     private RoleBasedAccessControlPolicyConfiguration policyConfiguration;
 
+    @Mock
+    private Environment environment;
+
+    @Before
+    public void init() {
+        when(mockExecutionContext.getComponent(Environment.class)).thenReturn(environment);
+        when(mockExecutionContext.request()).thenReturn(mockRequest);
+        when(mockExecutionContext.response()).thenReturn(mockResponse);
+    }
+
     @Test
     public void shouldFail_noUserRole() {
         RoleBasedAccessControlPolicy policy = new RoleBasedAccessControlPolicy(policyConfiguration);
 
         when(mockExecutionContext.getAttribute(ExecutionContext.ATTR_USER_ROLES)).thenReturn(null);
+        when(
+            environment.getProperty(
+                eq(RoleBasedAccessControlPolicy.RBAC_USER_ROLES_ATTRIBUTE_KEY),
+                eq(RoleBasedAccessControlPolicy.DEFAULT_RBAC_USER_ROLES_ATTRIBUTE)
+            )
+        )
+            .thenReturn(RoleBasedAccessControlPolicy.DEFAULT_RBAC_USER_ROLES_ATTRIBUTE);
 
         policy.onRequest(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
 
@@ -84,6 +105,13 @@ public class RoleBasedAccessControlPolicyTest {
 
         when(mockExecutionContext.getAttribute(ExecutionContext.ATTR_USER_ROLES)).thenReturn(new Object());
         when(policyConfiguration.hasRoles()).thenReturn(true);
+        when(
+            environment.getProperty(
+                eq(RoleBasedAccessControlPolicy.RBAC_USER_ROLES_ATTRIBUTE_KEY),
+                eq(RoleBasedAccessControlPolicy.DEFAULT_RBAC_USER_ROLES_ATTRIBUTE)
+            )
+        )
+            .thenReturn(RoleBasedAccessControlPolicy.DEFAULT_RBAC_USER_ROLES_ATTRIBUTE);
 
         policy.onRequest(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
 
@@ -111,6 +139,13 @@ public class RoleBasedAccessControlPolicyTest {
         when(policyConfiguration.getRoles()).thenReturn(new HashSet<>(Arrays.asList("read", "write", "admin")));
         when(policyConfiguration.isStrict()).thenReturn(true);
         when(policyConfiguration.hasRoles()).thenReturn(true);
+        when(
+            environment.getProperty(
+                eq(RoleBasedAccessControlPolicy.RBAC_USER_ROLES_ATTRIBUTE_KEY),
+                eq(RoleBasedAccessControlPolicy.DEFAULT_RBAC_USER_ROLES_ATTRIBUTE)
+            )
+        )
+            .thenReturn(RoleBasedAccessControlPolicy.DEFAULT_RBAC_USER_ROLES_ATTRIBUTE);
 
         policy.onRequest(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
 
@@ -125,6 +160,13 @@ public class RoleBasedAccessControlPolicyTest {
         when(policyConfiguration.getRoles()).thenReturn(new HashSet<>(Arrays.asList("read", "write", "admin")));
         when(policyConfiguration.isStrict()).thenReturn(false);
         when(policyConfiguration.hasRoles()).thenReturn(true);
+        when(
+            environment.getProperty(
+                eq(RoleBasedAccessControlPolicy.RBAC_USER_ROLES_ATTRIBUTE_KEY),
+                eq(RoleBasedAccessControlPolicy.DEFAULT_RBAC_USER_ROLES_ATTRIBUTE)
+            )
+        )
+            .thenReturn(RoleBasedAccessControlPolicy.DEFAULT_RBAC_USER_ROLES_ATTRIBUTE);
 
         policy.onRequest(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
 
@@ -139,6 +181,13 @@ public class RoleBasedAccessControlPolicyTest {
         when(policyConfiguration.getRoles()).thenReturn(new HashSet<>(Arrays.asList("read", "write", "admin")));
         when(policyConfiguration.isStrict()).thenReturn(true);
         when(policyConfiguration.hasRoles()).thenReturn(true);
+        when(
+            environment.getProperty(
+                eq(RoleBasedAccessControlPolicy.RBAC_USER_ROLES_ATTRIBUTE_KEY),
+                eq(RoleBasedAccessControlPolicy.DEFAULT_RBAC_USER_ROLES_ATTRIBUTE)
+            )
+        )
+            .thenReturn(RoleBasedAccessControlPolicy.DEFAULT_RBAC_USER_ROLES_ATTRIBUTE);
 
         policy.onRequest(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
 
@@ -166,6 +215,13 @@ public class RoleBasedAccessControlPolicyTest {
         when(policyConfiguration.getRoles()).thenReturn(new HashSet<>(Arrays.asList("read", "write")));
         when(policyConfiguration.isStrict()).thenReturn(true);
         when(policyConfiguration.hasRoles()).thenReturn(true);
+        when(
+            environment.getProperty(
+                eq(RoleBasedAccessControlPolicy.RBAC_USER_ROLES_ATTRIBUTE_KEY),
+                eq(RoleBasedAccessControlPolicy.DEFAULT_RBAC_USER_ROLES_ATTRIBUTE)
+            )
+        )
+            .thenReturn(RoleBasedAccessControlPolicy.DEFAULT_RBAC_USER_ROLES_ATTRIBUTE);
 
         policy.onRequest(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
 
@@ -180,6 +236,13 @@ public class RoleBasedAccessControlPolicyTest {
         when(policyConfiguration.getRoles()).thenReturn(new HashSet<>(Arrays.asList("read", "write", "admin")));
         when(policyConfiguration.isStrict()).thenReturn(false);
         when(policyConfiguration.hasRoles()).thenReturn(true);
+        when(
+            environment.getProperty(
+                eq(RoleBasedAccessControlPolicy.RBAC_USER_ROLES_ATTRIBUTE_KEY),
+                eq(RoleBasedAccessControlPolicy.DEFAULT_RBAC_USER_ROLES_ATTRIBUTE)
+            )
+        )
+            .thenReturn(RoleBasedAccessControlPolicy.DEFAULT_RBAC_USER_ROLES_ATTRIBUTE);
 
         policy.onRequest(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
 
@@ -197,5 +260,132 @@ public class RoleBasedAccessControlPolicyTest {
                     }
                 )
             );
+    }
+
+    private static final String GATEWAY_CONTEXT_ATTRIBUTE_ROLES = "gateway.roles";
+
+    @Test
+    public void testOnRequestHasRole_customRoleAttribute() throws Exception {
+        when(policyConfiguration.getRoles()).thenReturn(new HashSet<>(Arrays.asList("testrole", "testrole2")));
+        when(mockExecutionContext.getAttribute(GATEWAY_CONTEXT_ATTRIBUTE_ROLES)).thenReturn("[\"testrole\", \"testrole2\"]");
+        when(
+            environment.getProperty(
+                eq(RoleBasedAccessControlPolicy.RBAC_USER_ROLES_ATTRIBUTE_KEY),
+                eq(RoleBasedAccessControlPolicy.DEFAULT_RBAC_USER_ROLES_ATTRIBUTE)
+            )
+        )
+            .thenReturn(GATEWAY_CONTEXT_ATTRIBUTE_ROLES);
+        when(policyConfiguration.hasRoles()).thenReturn(true);
+
+        RoleBasedAccessControlPolicy policy = new RoleBasedAccessControlPolicy(policyConfiguration);
+        policy.onRequest(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+
+        verify(mockPolicychain).doNext(mockRequest, mockResponse);
+    }
+
+    @Test
+    public void testOnRequestHasRole_stringRole_customRoleAttribute() throws Exception {
+        when(policyConfiguration.getRoles()).thenReturn(new HashSet<>(Arrays.asList("testrole", "testrole2")));
+        when(mockExecutionContext.getAttribute(GATEWAY_CONTEXT_ATTRIBUTE_ROLES)).thenReturn("testrole testrole2");
+        when(
+            environment.getProperty(
+                eq(RoleBasedAccessControlPolicy.RBAC_USER_ROLES_ATTRIBUTE_KEY),
+                eq(RoleBasedAccessControlPolicy.DEFAULT_RBAC_USER_ROLES_ATTRIBUTE)
+            )
+        )
+            .thenReturn(GATEWAY_CONTEXT_ATTRIBUTE_ROLES);
+        when(policyConfiguration.hasRoles()).thenReturn(true);
+
+        RoleBasedAccessControlPolicy policy = new RoleBasedAccessControlPolicy(policyConfiguration);
+        policy.onRequest(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+
+        verify(mockPolicychain).doNext(mockRequest, mockResponse);
+    }
+
+    @Test
+    public void testOnRequestHasRole_stringRoleWithSpaces_customRoleAttribute() throws Exception {
+        when(policyConfiguration.getRoles()).thenReturn(new HashSet<>(Arrays.asList("testrole", "testrole2")));
+        when(mockExecutionContext.getAttribute(GATEWAY_CONTEXT_ATTRIBUTE_ROLES)).thenReturn("testrole,  testrole2");
+        when(
+            environment.getProperty(
+                eq(RoleBasedAccessControlPolicy.RBAC_USER_ROLES_ATTRIBUTE_KEY),
+                eq(RoleBasedAccessControlPolicy.DEFAULT_RBAC_USER_ROLES_ATTRIBUTE)
+            )
+        )
+            .thenReturn(GATEWAY_CONTEXT_ATTRIBUTE_ROLES);
+        when(policyConfiguration.hasRoles()).thenReturn(true);
+
+        RoleBasedAccessControlPolicy policy = new RoleBasedAccessControlPolicy(policyConfiguration);
+        policy.onRequest(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+
+        verify(mockPolicychain).doNext(mockRequest, mockResponse);
+    }
+
+    @Test
+    public void testOnRequestNoRole_customRoleAttribute() throws Exception {
+        when(mockExecutionContext.getAttribute(GATEWAY_CONTEXT_ATTRIBUTE_ROLES)).thenReturn(null);
+        when(environment.getProperty(eq(RoleBasedAccessControlPolicy.RBAC_USER_ROLES_ATTRIBUTE_KEY), anyString()))
+            .thenReturn(GATEWAY_CONTEXT_ATTRIBUTE_ROLES);
+
+        RoleBasedAccessControlPolicy policy = new RoleBasedAccessControlPolicy(policyConfiguration);
+        policy.onRequest(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+
+        verify(mockPolicychain).failWith(any(PolicyResult.class));
+    }
+
+    @Test
+    public void testOnRequestEmptyRole_customRoleAttribute() throws Exception {
+        when(mockExecutionContext.getAttribute(GATEWAY_CONTEXT_ATTRIBUTE_ROLES)).thenReturn("[]");
+        when(
+            environment.getProperty(
+                eq(RoleBasedAccessControlPolicy.RBAC_USER_ROLES_ATTRIBUTE_KEY),
+                eq(RoleBasedAccessControlPolicy.DEFAULT_RBAC_USER_ROLES_ATTRIBUTE)
+            )
+        )
+            .thenReturn(GATEWAY_CONTEXT_ATTRIBUTE_ROLES);
+        when(policyConfiguration.hasRoles()).thenReturn(true);
+
+        RoleBasedAccessControlPolicy policy = new RoleBasedAccessControlPolicy(policyConfiguration);
+        policy.onRequest(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+
+        verify(mockPolicychain).failWith(any(PolicyResult.class));
+    }
+
+    @Test
+    public void testOnRequestHasNoMatchRole_customRoleAttribute() throws Exception {
+        when(policyConfiguration.getRoles()).thenReturn(new HashSet<>(Arrays.asList("testrole", "testrole2")));
+        when(mockExecutionContext.getAttribute(GATEWAY_CONTEXT_ATTRIBUTE_ROLES)).thenReturn("[\"testrole1\", \"testrole3\"]");
+        when(
+            environment.getProperty(
+                eq(RoleBasedAccessControlPolicy.RBAC_USER_ROLES_ATTRIBUTE_KEY),
+                eq(RoleBasedAccessControlPolicy.DEFAULT_RBAC_USER_ROLES_ATTRIBUTE)
+            )
+        )
+            .thenReturn(GATEWAY_CONTEXT_ATTRIBUTE_ROLES);
+        when(policyConfiguration.hasRoles()).thenReturn(true);
+
+        RoleBasedAccessControlPolicy policy = new RoleBasedAccessControlPolicy(policyConfiguration);
+        policy.onRequest(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+
+        verify(mockPolicychain).failWith(any(PolicyResult.class));
+    }
+
+    @Test
+    public void testOnRequestHasMatchRole_customRoleAttribute() throws Exception {
+        when(policyConfiguration.getRoles()).thenReturn(new HashSet<>(Arrays.asList("testrole", "testrole2")));
+        when(mockExecutionContext.getAttribute(GATEWAY_CONTEXT_ATTRIBUTE_ROLES)).thenReturn("[\"testrole\", \"testrole3\"]");
+        when(
+            environment.getProperty(
+                eq(RoleBasedAccessControlPolicy.RBAC_USER_ROLES_ATTRIBUTE_KEY),
+                eq(RoleBasedAccessControlPolicy.DEFAULT_RBAC_USER_ROLES_ATTRIBUTE)
+            )
+        )
+            .thenReturn(GATEWAY_CONTEXT_ATTRIBUTE_ROLES);
+        when(policyConfiguration.hasRoles()).thenReturn(true);
+
+        RoleBasedAccessControlPolicy policy = new RoleBasedAccessControlPolicy(policyConfiguration);
+        policy.onRequest(mockRequest, mockResponse, mockExecutionContext, mockPolicychain);
+
+        verify(mockPolicychain).doNext(mockRequest, mockResponse);
     }
 }


### PR DESCRIPTION
…er's roles

**Issue**

https://gravitee.atlassian.net/browse/APIM-1506

**Description**

This PR is providing additional configuration at the gateway level (gravitee.yml) for configuring the attribute from which the policy will extract the user's roles.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.4.0-apim-1506-rbac-custom-attribute-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-role-based-access-control/1.4.0-apim-1506-rbac-custom-attribute-SNAPSHOT/gravitee-policy-role-based-access-control-1.4.0-apim-1506-rbac-custom-attribute-SNAPSHOT.zip)
  <!-- Version placeholder end -->
