### PR TITLE
feat: enable for A2A proxy

### DIFF
--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -11,3 +11,4 @@ http_proxy=REQUEST
 http_message=REQUEST
 mcp_proxy=REQUEST
 llm_proxy=REQUEST
+a2a_proxy=REQUEST


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-12548

**Description**

Enable for A2A proxy.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-apim-12548-enable-for-a2a-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-role-based-access-control/2.1.0-apim-12548-enable-for-a2a-SNAPSHOT/gravitee-policy-role-based-access-control-2.1.0-apim-12548-enable-for-a2a-SNAPSHOT.zip)
  <!-- Version placeholder end -->
